### PR TITLE
Adds AgnosticUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A curated list of design systems made up of reusable
 
 #### React Design Systems
 
+- [AgnosticUI](https://www.agnosticui.com/) [[GitHub](https://github.com/AgnosticUI/agnosticui)] - Accessible React component primitives that also work with Vue 3, Svelte, and Angular.
 - [Ant Design](https://ant.design/) [[github](https://github.com/ant-design/ant-design/)] - Ant Financial - A design system with values of Nature and Determinacy for better user experience of enterprise applications.
 - [Atlaskit](http://atlaskit.atlassian.com/) [[bitbucket](https://bitbucket.org/atlassian/atlaskit-mk-2)] - Atlassian - Atlassian's official UI library, built according to the Atlassian Design Guidelines.
 - [Backpack](https://backpack.github.io/) [[github](https://github.com/Skyscanner/backpack)] - Skyscanner - Backpack is a collection of design resources, reusable components and guidelines for creating Skyscanner products.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A curated list of design systems made up of reusable
 
 #### React Design Systems
 
-- [AgnosticUI](https://www.agnosticui.com/) [[GitHub](https://github.com/AgnosticUI/agnosticui)] - Accessible React component primitives that also work with Vue 3, Svelte, and Angular.
+- [AgnosticUI](https://www.agnosticui.com/) [[gitHub](https://github.com/AgnosticUI/agnosticui)] - Accessible React component primitives that also work with Vue 3, Svelte, and Angular.
 - [Ant Design](https://ant.design/) [[github](https://github.com/ant-design/ant-design/)] - Ant Financial - A design system with values of Nature and Determinacy for better user experience of enterprise applications.
 - [Atlaskit](http://atlaskit.atlassian.com/) [[bitbucket](https://bitbucket.org/atlassian/atlaskit-mk-2)] - Atlassian - Atlassian's official UI library, built according to the Atlassian Design Guidelines.
 - [Backpack](https://backpack.github.io/) [[github](https://github.com/Skyscanner/backpack)] - Skyscanner - Backpack is a collection of design resources, reusable components and guidelines for creating Skyscanner products.


### PR DESCRIPTION
Hi @jbranchaud -- this adds AgnosticUI to the list. I noticed it was alphabetically ordered so preserved that:

![image](https://user-images.githubusercontent.com/142403/161164706-d46551f2-da07-4f26-9c12-a865da21d79b.png)

I realize this selfishly puts AgnosticUI at the top of the list so of course lmk if you'd prefer that placed differently 🚀 